### PR TITLE
PATCH SUPEE-8167 EE 1.14.1.0 1.14.3.2 v1-2017-05-08-02-42-22

### DIFF
--- a/app/code/core/Mage/Paypal/Model/Ipn.php
+++ b/app/code/core/Mage/Paypal/Model/Ipn.php
@@ -37,6 +37,20 @@ class Mage_Paypal_Model_Ipn
     const DEFAULT_LOG_FILE = 'paypal_unknown_ipn.log';
 
     /**
+     * Default postback endpoint URL.
+     *
+     * @var string
+     */
+    const DEFAULT_POSTBACK_URL = 'https://ipnpb.paypal.com/cgi-bin/webscr';
+
+    /**
+     * Sandbox postback endpoint URL.
+     *
+     * @var string
+     */
+    const SANDBOX_POSTBACK_URL = 'https://ipnpb.sandbox.paypal.com/cgi-bin/webscr';
+
+    /**
      * Store order instance
      *
      * @var Mage_Sales_Model_Order
@@ -133,14 +147,15 @@ class Mage_Paypal_Model_Ipn
      */
     protected function _postBack(Zend_Http_Client_Adapter_Interface $httpAdapter)
     {
+        $url = $this->_getPostbackUrl();
+
         $postbackQuery = http_build_query($this->_request) . '&cmd=_notify-validate';
-        $postbackUrl = $this->_config->getPostbackUrl();
-        $this->_debugData['postback_to'] = $postbackUrl;
+        $this->_debugData['postback_to'] = $url;
 
         $httpAdapter->setConfig(array('verifypeer' => $this->_config->verifyPeer));
         $httpAdapter->write(
             Zend_Http_Client::POST,
-            $postbackUrl,
+            $url,
             '1.1',
             array('Connection: close'),
             $postbackQuery
@@ -174,6 +189,16 @@ class Mage_Paypal_Model_Ipn
             $this->_debugData['postback_result'] = $postbackResult;
             throw new Exception('PayPal IPN postback failure. See ' . self::DEFAULT_LOG_FILE . ' for details.');
         }
+    }
+
+    /**
+     * Get postback endpoint URL.
+     *
+     * @return string
+     */
+    protected function _getPostbackUrl()
+    {
+        return $this->_config->sandboxFlag ? self::SANDBOX_POSTBACK_URL : self::DEFAULT_POSTBACK_URL;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "firegento/magento",
+    "name": "flagbit/magento-community",
     "type": "magento-core",
     "license": ["OSL-3.0", "AFL-3.0"],
     "description": "Magento CE"


### PR DESCRIPTION
Hey, in your magento version 1.9.3.3. there is the patch SUPEE-8167 missing.

**See**
https://magento.com/tech-resources/download?_ga=2.33092921.683408746.1498461872-518715573.1490859397#download2007

Can you merge and regenerate the tag v1.9.3.3 ?

Thx ;-)